### PR TITLE
Fix typo in services page

### DIFF
--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -27,7 +27,7 @@ export default function ServicesPage() {
           <div className="border rounded-lg p-6 shadow hover:shadow-md transition">
             <h2 className="text-2xl font-semibold">🛠️ Contract Development</h2>
             <p className="text-gray-700 mt-2">
-              Available for 3–6 month contract work in Unreal Engine, game development, 3D animation, ormotion design integration. Includes high-end prototyping, design, optimization, and support.
+              Available for 3–6 month contract work in Unreal Engine, game development, 3D animation, or motion design integration. Includes high-end prototyping, design, optimization, and support.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fix small typo in Contract Development section on the services page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f53e620008325bfb8317e21e51c62