### PR TITLE
Fix next-sitemap config export

### DIFF
--- a/next-sitemap.config.ts
+++ b/next-sitemap.config.ts
@@ -1,17 +1,21 @@
-// next-sitemap.config.js
-module.exports = {
-    siteUrl: 'https://loganpinney.com',   // ← your production URL
-    generateRobotsTxt: true,              // ← creates robots.txt
-    changefreq: 'weekly',                 // ← default change frequency
-    priority: 0.7,                        // ← default priority
-    exclude: [
-      '/admin/*',                         // ← any paths you don’t want indexed
-      '/drafts/*'
-    ],
-    robotsTxtOptions: {
-      additionalSitemaps: [
-        'https://loganpinney.com/sitemap.xml',
-        // you can list extra sitemap chunks if you split them
-      ]
-    }
+// next-sitemap.config.ts
+import type { IConfig } from 'next-sitemap'
+
+const config: IConfig = {
+  siteUrl: 'https://loganpinney.com',   // ← your production URL
+  generateRobotsTxt: true,              // ← creates robots.txt
+  changefreq: 'weekly',                 // ← default change frequency
+  priority: 0.7,                        // ← default priority
+  exclude: [
+    '/admin/*',                         // ← any paths you don’t want indexed
+    '/drafts/*'
+  ],
+  robotsTxtOptions: {
+    additionalSitemaps: [
+      'https://loganpinney.com/sitemap.xml',
+      // you can list extra sitemap chunks if you split them
+    ]
   }
+}
+
+export default config


### PR DESCRIPTION
## Summary
- use typed config with `export default` in `next-sitemap.config.ts`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f53f5c78483258f3fc11d071059ad